### PR TITLE
refactor: use the TS compiler option `jsx: react-jsx` to avoid having to specify JSX renderer

### DIFF
--- a/src/App.stories.tsx
+++ b/src/App.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import { params, parent, semantics } from '../.storybook/helpers/h5p.utils';
 import { App } from './App';
 import { ArrowType } from './types/ArrowType';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import type { H5PFieldGroup, H5PForm } from 'h5p-types';
-import * as React from 'react';
+import { FC, useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { MapEditorView } from './components/MapEditorView/MapEditorView';
 import { AppWidthContext } from './contexts/AppWidthContext';
 import { Params } from './types/Params';
@@ -17,16 +17,16 @@ export type AppProps = {
   parent: H5PForm;
 };
 
-export const App: React.FC<AppProps> = ({
+export const App: FC<AppProps> = ({
   setValue,
   semantics,
   initialParams,
   parent,
 }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [width, setWidth] = React.useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     const initialWidth =
       containerRef.current?.getBoundingClientRect().width ?? 0;
     setWidth(initialWidth);
@@ -36,13 +36,13 @@ export const App: React.FC<AppProps> = ({
     setWidth(contentRect.width);
   });
 
-  const [params, setParams] = React.useState<Params>(
+  const [params, setParams] = useState<Params>(
     initialParams
       ? fillInMissingParamsProperties(initialParams)
       : getEmptyParams(),
   );
 
-  const updateParams = React.useCallback(
+  const updateParams = useCallback(
     (updatedParams: Partial<Params>) => {
       const newParams: Params = {
         ...params,

--- a/src/H5P/H5PWrapper.tsx
+++ b/src/H5P/H5PWrapper.tsx
@@ -1,6 +1,5 @@
 import type { H5PFieldGroup, IH5PWidget } from 'h5p-types';
 import { H5PWidget } from 'h5p-utils';
-import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from '../App';
 import { Params } from '../types/Params';

--- a/src/components/AppearanceDialog/AppearanceDialog.stories.tsx
+++ b/src/components/AppearanceDialog/AppearanceDialog.stories.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-
 import { AppearanceDialog } from './AppearanceDialog';
 import { getBackgroundImageField } from '../../utils/H5P/form.utils';
 import {

--- a/src/components/AppearanceDialog/AppearanceDialog.tsx
+++ b/src/components/AppearanceDialog/AppearanceDialog.tsx
@@ -1,5 +1,5 @@
 import type { H5PFieldImage, H5PForm } from 'h5p-types';
-import * as React from 'react';
+import { FC } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { ColorTheme } from '../../types/ColorTheme';
 import { Params } from '../../types/Params';
@@ -18,7 +18,7 @@ export type AppearanceDialogProps = {
   onSave: (params: Params) => void;
 };
 
-export const AppearanceDialog: React.FC<AppearanceDialogProps> = ({
+export const AppearanceDialog: FC<AppearanceDialogProps> = ({
   backgroundImageField,
   isOpen,
   onSave,

--- a/src/components/Arrow/Arrow.stories.tsx
+++ b/src/components/Arrow/Arrow.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Arrow } from './Arrow';
 import { ArrowType } from '../../types/ArrowType';

--- a/src/components/Arrow/Arrow.tsx
+++ b/src/components/Arrow/Arrow.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
-import * as React from 'react';
 import { H5P } from 'h5p-utils';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { ArrowItemType } from '../../types/ArrowItemType';
 import { ArrowType } from '../../types/ArrowType';
@@ -31,7 +31,7 @@ export type ArrowProps = {
 };
 
 // TODO: Share code with h5p-topic-map instead of duplicating
-export const Arrow: React.FC<ArrowProps> = ({
+export const Arrow: FC<ArrowProps> = ({
   item,
   cellSize,
   gapSize,
@@ -46,19 +46,18 @@ export const Arrow: React.FC<ArrowProps> = ({
   const arrowHeadID = H5P.createUUID();
   const arrowTailID = H5P.createUUID();
 
-  const [showDeleteConfirmationDialog, setShowDeleteConfirmationDialog] =
-    React.useState(false);
+  const [showDeleteConfirmationDialog, setShowDeleteConfirmationDialog] = useState(false);
 
-  const confirmDeletion = React.useCallback(() => {
+  const confirmDeletion = useCallback(() => {
     deleteItem(item.id);
     setShowDeleteConfirmationDialog(false);
   }, [deleteItem, item.id]);
 
-  const denyDeletion = React.useCallback(() => {
+  const denyDeletion = useCallback(() => {
     setShowDeleteConfirmationDialog(false);
   }, []);
 
-  const contextMenuActions: Array<ContextMenuAction> = React.useMemo(() => {
+  const contextMenuActions: Array<ContextMenuAction> = useMemo(() => {
     const editAction: ContextMenuAction = {
       icon: ContextMenuButtonType.Edit,
       label: t('context-menu_edit'),

--- a/src/components/ArrowIndicator/ArrowIndicator.tsx
+++ b/src/components/ArrowIndicator/ArrowIndicator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC } from 'react';
 import { Position } from '../../types/Position';
 
 export type ArrowIndicatorProps = {
@@ -7,7 +7,7 @@ export type ArrowIndicatorProps = {
   gapSize: number;
 };
 
-export const ArrowIndicator: React.FC<ArrowIndicatorProps> = ({
+export const ArrowIndicator: FC<ArrowIndicatorProps> = ({
   position,
   cellSize,
   gapSize,

--- a/src/components/ArrowIndicator/ArrowIndicatorContainer.tsx
+++ b/src/components/ArrowIndicator/ArrowIndicatorContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC } from 'react';
 import { Position } from '../../types/Position';
 import styles from './ArrowIndicator.module.scss';
 
@@ -11,7 +11,7 @@ export type ArrowIndicatorProps = {
 };
 
 // TODO: Share code with h5p-topic-map instead of duplicating
-export const ArrowIndicatorContainer: React.FC<ArrowIndicatorProps> = ({
+export const ArrowIndicatorContainer: FC<ArrowIndicatorProps> = ({
   arrowIndicators,
   breakpoints,
   cellSize,

--- a/src/components/ArrowItemForm/ArrowItemForm.stories.tsx
+++ b/src/components/ArrowItemForm/ArrowItemForm.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import {
   params,
   parent,

--- a/src/components/ArrowItemForm/ArrowItemForm.tsx
+++ b/src/components/ArrowItemForm/ArrowItemForm.tsx
@@ -1,5 +1,5 @@
 import type { H5PField, H5PFieldGroup, H5PForm } from 'h5p-types';
-import * as React from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { Params } from '../../types/Params';
 import { getArrowItemsField } from '../../utils/H5P/form.utils';
 import { SemanticsForm } from '../SemanticsForm/SemanticsForm';
@@ -13,17 +13,17 @@ export type ArrowItemFormProps = {
   onSave: (params: Params) => void;
 };
 
-export const ArrowItemForm: React.FC<ArrowItemFormProps> = ({
+export const ArrowItemForm: FC<ArrowItemFormProps> = ({
   semantics,
   params,
   parent,
   itemId,
   onSave,
 }) => {
-  const [arrowItemField, setArrowItemField] = React.useState<H5PField | null>();
-  const [formParams, setFormParams] = React.useState<Params>();
+  const [arrowItemField, setArrowItemField] = useState<H5PField | null>();
+  const [formParams, setFormParams] = useState<Params>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const field = getArrowItemsField(semantics);
     setArrowItemField(field);
 
@@ -37,7 +37,7 @@ export const ArrowItemForm: React.FC<ArrowItemFormProps> = ({
     });
   }, [itemId, params, semantics]);
 
-  const onUpdate = React.useCallback(
+  const onUpdate = useCallback(
     (newParams: Params) => {
       if (!newParams.arrowItems) {
         return;

--- a/src/components/ClassicArrowParts/ArrowParts.tsx
+++ b/src/components/ClassicArrowParts/ArrowParts.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 import styles from './ArrowParts.module.scss';
 
 const bodySizePercentage = 38;
 const bodyPositionPercentage = (100 - bodySizePercentage) / 2;
 
-export const ArrowBody: React.FC = (): JSX.Element => {
+export const ArrowBody: FC = (): JSX.Element => {
   return (
     <svg
       className={styles.bodyHorizontal}
@@ -21,7 +21,7 @@ export const ArrowBody: React.FC = (): JSX.Element => {
   );
 };
 
-export const ArrowBodyVertical: React.FC = (): JSX.Element => {
+export const ArrowBodyVertical: FC = (): JSX.Element => {
   return (
     <svg
       className={styles.bodyVertical}
@@ -38,7 +38,7 @@ export const ArrowBodyVertical: React.FC = (): JSX.Element => {
   );
 };
 
-export const ArrowHead: React.FC = (): JSX.Element => {
+export const ArrowHead: FC = (): JSX.Element => {
   return (
     <svg
       className={styles.headHorizontal}
@@ -50,7 +50,7 @@ export const ArrowHead: React.FC = (): JSX.Element => {
   );
 };
 
-export const ArrowHeadVertical: React.FC = (): JSX.Element => {
+export const ArrowHeadVertical: FC = (): JSX.Element => {
   return (
     <svg
       className={styles.headVertical}
@@ -62,7 +62,7 @@ export const ArrowHeadVertical: React.FC = (): JSX.Element => {
   );
 };
 
-export const MirroredArrowHead: React.FC = (): JSX.Element => {
+export const MirroredArrowHead: FC = (): JSX.Element => {
   return (
     <svg
       className={`${styles.headHorizontal} ${styles.mirrorX}`}
@@ -74,7 +74,7 @@ export const MirroredArrowHead: React.FC = (): JSX.Element => {
   );
 };
 
-export const MirroredArrowHeadVertical: React.FC = (): JSX.Element => {
+export const MirroredArrowHeadVertical: FC = (): JSX.Element => {
   return (
     <svg
       className={`${styles.headVertical} ${styles.mirrorY}`}

--- a/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ContextMenu, ContextMenuButtonType } from './ContextMenu';
 

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import styles from './ContextMenu.module.scss';
-import { ContextMenuButton } from '../ContextMenuButton/ContextMenuButton';
+import { FC } from 'react';
 import { ContextMenuAction } from '../../types/ContextMenuAction';
+import { ContextMenuButton } from '../ContextMenuButton/ContextMenuButton';
+import styles from './ContextMenu.module.scss';
 
 /*
   Name of svg icon should be similar to this,
@@ -24,7 +24,7 @@ export type ContextMenuProps = {
   gridWidth?: number;
 };
 
-export const ContextMenu: React.FC<ContextMenuProps> = ({
+export const ContextMenu: FC<ContextMenuProps> = ({
   show,
   turnLeft,
   actions,

--- a/src/components/ContextMenuButton/ContextMenuButton.stories.tsx
+++ b/src/components/ContextMenuButton/ContextMenuButton.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ContextMenuButtonType } from '../ContextMenu/ContextMenu';
 

--- a/src/components/ContextMenuButton/ContextMenuButton.tsx
+++ b/src/components/ContextMenuButton/ContextMenuButton.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
 import styles from './ContextMenuButton.module.scss';
 import { Icon } from '../Icons/Icons';
 import { ContextMenuButtonType } from '../ContextMenu/ContextMenu';
+import { FC, MouseEventHandler } from 'react';
 
 export type ContextMenuButtonProps = {
   icon: ContextMenuButtonType;
   label: string;
-  onClick: React.MouseEventHandler;
+  onClick: MouseEventHandler;
 };
 
-export const ContextMenuButton: React.FC<ContextMenuButtonProps> = ({
+export const ContextMenuButton: FC<ContextMenuButtonProps> = ({
   icon,
   label,
   onClick,

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import { Dialog } from './Dialog';
 
 const componentMeta: ComponentMeta<typeof Dialog> = {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
 import {
-  Root,
-  Overlay,
-  Content,
-  Title,
-  Description,
   Close,
+  Content,
+  Description,
+  Overlay,
+  Root,
+  Title,
 } from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
-import styles from './Dialog.module.scss';
+import { FC, ReactElement } from 'react';
 import { t } from '../../H5P/H5P.util';
+import styles from './Dialog.module.scss';
 
 type DialogSize = 'medium' | 'large';
 
@@ -19,7 +19,7 @@ export type DialogProps = {
   description?: string | undefined;
   onOpenChange: (open: boolean) => void;
   size: DialogSize;
-  children: React.ReactElement | null | Array<React.ReactElement | null>;
+  children: ReactElement | null | Array<ReactElement | null>;
 };
 
 const maxWidths: Record<DialogSize, number> = {
@@ -27,7 +27,7 @@ const maxWidths: Record<DialogSize, number> = {
   large: 750,
 };
 
-export const Dialog: React.FC<DialogProps> = ({
+export const Dialog: FC<DialogProps> = ({
   isOpen,
   title,
   description,

--- a/src/components/Draggable/Draggable.stories.tsx
+++ b/src/components/Draggable/Draggable.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import { Draggable } from './Draggable';
 
 export default {

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FC,  useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { ContextMenuAction } from '../../types/ContextMenuAction';
 import { OccupiedCell } from '../../types/OccupiedCell';

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import {
   semantics,
   params,

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,5 +1,4 @@
 import { H5P } from 'h5p-utils';
-import * as React from 'react';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 import { t } from '../../H5P/H5P.util';
@@ -199,10 +198,11 @@ export const Grid: FC<GridProps> = ({
           .find((element) =>
             element.classList.contains('grid-indicator'),
           ) as HTMLElement;
-        const gridPosition = {
+          
+        const gridPosition: Position = {
           x: parseInt(gridIndicator.dataset.x as string, 10),
           y: parseInt(gridIndicator.dataset.y as string, 10),
-        } as Position;
+        };
 
         const hasStartElementId = !!arrowStartId;
         if (!hasStartElementId) {

--- a/src/components/GridIndicator/GridIndicator.stories.tsx
+++ b/src/components/GridIndicator/GridIndicator.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { GridIndicator } from './GridIndicator';

--- a/src/components/GridIndicator/GridIndicator.tsx
+++ b/src/components/GridIndicator/GridIndicator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC, memo } from 'react';
 import { Position } from '../../types/Position';
 import styles from './GridIndicator.module.scss';
 
@@ -9,7 +9,7 @@ export type GridIndicatorProps = {
   position: Position;
 };
 
-export const GridIndicator: React.FC<GridIndicatorProps> = React.memo(
+export const GridIndicator: FC<GridIndicatorProps> = memo(
   ({ onMouseDown, onMouseEnter, label, position }) => {
     return (
       <button

--- a/src/components/Icons/Icons.tsx
+++ b/src/components/Icons/Icons.tsx
@@ -1,20 +1,20 @@
-import * as React from 'react';
-import { MapAppearance } from '../../icons/MapAppearance';
-import { CreateBox } from '../../icons/CreateBox';
-import { CreateArrow } from '../../icons/CreateArrow';
-import { Edit } from '../../icons/Edit';
-import { Delete } from '../../icons/Delete';
+import { FC } from 'react';
 import { BiDirectionalArrow } from '../../icons/BiDirectionalArrow';
+import { CreateArrow } from '../../icons/CreateArrow';
+import { CreateBox } from '../../icons/CreateBox';
+import { Delete } from '../../icons/Delete';
+import { Edit } from '../../icons/Edit';
+import { MapAppearance } from '../../icons/MapAppearance';
 import { SingleLine } from '../../icons/SingleLine';
-import { ToolbarButtonType } from '../Toolbar/Toolbar';
 import { ContextMenuButtonType } from '../ContextMenu/ContextMenu';
+import { ToolbarButtonType } from '../Toolbar/Toolbar';
 
 export type IconProps = {
   icon: ToolbarButtonType | ContextMenuButtonType;
   className: string;
 };
 
-export const Icon: React.FC<IconProps> = ({ icon, className }) => {
+export const Icon: FC<IconProps> = ({ icon, className }) => {
   const icons = {
     [ToolbarButtonType.MapAppearance]: MapAppearance,
     [ToolbarButtonType.CreateBox]: CreateBox,

--- a/src/components/MapEditorView/MapEditorView.stories.tsx
+++ b/src/components/MapEditorView/MapEditorView.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import {
   params,
   parent,

--- a/src/components/MapEditorView/MapEditorView.tsx
+++ b/src/components/MapEditorView/MapEditorView.tsx
@@ -1,14 +1,13 @@
-import type { H5PForm, H5PFieldGroup } from 'h5p-types';
+import type { H5PFieldGroup, H5PForm } from 'h5p-types';
 import { getImageUrl } from 'h5p-utils';
-import * as React from 'react';
-import { useState } from 'react';
+import { FC, useCallback, useMemo, useRef, useState } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { ArrowItemType } from '../../types/ArrowItemType';
 import { Params } from '../../types/Params';
 import { TopicMapItemType } from '../../types/TopicMapItemType';
+import { getBackgroundImageField } from '../../utils/H5P/form.utils';
 import { updateArrowLabels } from '../../utils/arrow.utils';
 import { findConnectedArrows } from '../../utils/grid.utils';
-import { getBackgroundImageField } from '../../utils/H5P/form.utils';
 import { ArrowItemForm } from '../ArrowItemForm/ArrowItemForm';
 import { Dialog } from '../Dialog/Dialog';
 import { Grid, GridDimensions } from '../Grid/Grid';
@@ -26,7 +25,7 @@ export type MapEditorViewProps = {
   setParams: (updatedParams: Partial<Params>) => void;
 };
 
-export const MapEditorView: React.FC<MapEditorViewProps> = ({
+export const MapEditorView: FC<MapEditorViewProps> = ({
   gapSize,
   numberOfColumns,
   numberOfRows,
@@ -54,7 +53,7 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
   const [editedArrow, setEditedArrow] = useState<string | null>(null);
   const [showDeleteConfirmationDialog, setShowDeleteConfirmationDialog] =
     useState(false);
-  const updateGrid = React.useRef((newItems: TopicMapItemType[]): void =>
+  const updateGrid = useRef((newItems: TopicMapItemType[]): void =>
     updateGrid.current(newItems),
   );
 
@@ -62,14 +61,14 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
     setActiveTool(newValue);
   };
 
-  const updateGridDimensions = React.useCallback(
+  const updateGridDimensions = useCallback(
     (newGrid: GridDimensions): void => {
       setParams({ grid: newGrid });
     },
     [setParams],
   );
 
-  const updateArrows = React.useCallback(
+  const updateArrows = useCallback(
     (items: Array<ArrowItemType>) => {
       setParams({ arrowItems: items });
       setArrowItems(items);
@@ -77,7 +76,7 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
     [setParams],
   );
 
-  const updateItems = React.useCallback(
+  const updateItems = useCallback(
     (items: Array<TopicMapItemType>) => {
       // Update arrow labels to match mapItem labels
       if (arrowItems.length > 0) {
@@ -93,12 +92,12 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
     [arrowItems, setParams, updateArrows],
   );
 
-  const openDeleteDialogue = React.useCallback((itemId: string) => {
+  const openDeleteDialogue = useCallback((itemId: string) => {
     setDeletedItem(itemId);
     setShowDeleteConfirmationDialog(true);
   }, []);
 
-  const deleteArrow = React.useCallback(
+  const deleteArrow = useCallback(
     (id: string) => {
       const newItems = arrowItems.filter((item) => item.id !== id);
 
@@ -108,7 +107,7 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
     [arrowItems, updateArrows],
   );
 
-  const deleteItem = React.useCallback(() => {
+  const deleteItem = useCallback(() => {
     const newItems = gridItems.filter((item) => item.id !== deletedItem);
 
     const connectedArrows = findConnectedArrows(deletedItem ?? '', arrowItems);
@@ -122,13 +121,13 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
     setCurrentItemsLength(newItems.length);
   }, [arrowItems, deleteArrow, deletedItem, gridItems, updateItems]);
 
-  const denyDeletion = React.useCallback(() => {
+  const denyDeletion = useCallback(() => {
     setShowDeleteConfirmationDialog(false);
     setSelectedItem(null);
   }, []);
 
   const topicMapItemFormDialogTitle = t('map-editor-view_item-dialog-title');
-  const backgroundImageField = React.useMemo(() => {
+  const backgroundImageField = useMemo(() => {
     const bgImgField = getBackgroundImageField(semantics);
 
     if (!bgImgField) {

--- a/src/components/ScaleHandle/ScaleHandle.tsx
+++ b/src/components/ScaleHandle/ScaleHandle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC, useCallback, useEffect, useRef, useState, MouseEvent, TouchEvent } from 'react';
 import { capitalize } from '../../utils/string.utils';
 import styles from './ScaleHandle.module.scss';
 
@@ -17,19 +17,19 @@ export type ScaleHandleProps = {
   onScaleStart: () => void;
 };
 
-export const ScaleHandle: React.FC<ScaleHandleProps> = ({
+export const ScaleHandle: FC<ScaleHandleProps> = ({
   labelText,
   position,
   onScaleStop,
   onScaleStart,
 }) => {
-  const [isDragging, setIsDragging] = React.useState(false);
-  const elementRef = React.useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
   const className =
     styles[`scaleHandle${position.split('-').map(capitalize).join('')}`];
 
-  const startDrag = React.useCallback(
-    (event: React.MouseEvent | React.TouchEvent) => {
+  const startDrag = useCallback(
+    (event: MouseEvent | TouchEvent) => {
       setIsDragging(true);
       onScaleStart();
 
@@ -38,7 +38,7 @@ export const ScaleHandle: React.FC<ScaleHandleProps> = ({
     [onScaleStart],
   );
 
-  const stopDrag = React.useCallback(() => {
+  const stopDrag = useCallback(() => {
     if (!isDragging) {
       return;
     }
@@ -47,7 +47,7 @@ export const ScaleHandle: React.FC<ScaleHandleProps> = ({
     onScaleStop();
   }, [isDragging, onScaleStop]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     /* 
       These are tied to `window`, because the
       cursor might not be on top of the element

--- a/src/components/ScaleHandles/ScaleHandles.tsx
+++ b/src/components/ScaleHandles/ScaleHandles.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC } from 'react';
 import { ResizeDirection } from '../../types/ResizeDirection';
 import { ScaleHandle } from '../ScaleHandle/ScaleHandle';
 
@@ -10,7 +10,7 @@ export type ScaleHandlesProps = {
   horizontalScaleHandleLabelText: string;
 };
 
-export const ScaleHandles: React.FC<ScaleHandlesProps> = ({
+export const ScaleHandles: FC<ScaleHandlesProps> = ({
   setIsResizing,
   startResize,
   stopResize,

--- a/src/components/SemanticsForm/SemanticsForm.tsx
+++ b/src/components/SemanticsForm/SemanticsForm.tsx
@@ -1,6 +1,6 @@
 import type { H5PField, H5PForm } from 'h5p-types';
 import { H5PEditor } from 'h5p-utils';
-import * as React from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { Params } from '../../types/Params';
 import styles from './SemanticsForm.module.scss';
@@ -13,22 +13,22 @@ export type SemanticsFormProps = {
   formClassName?: string;
 };
 
-export const SemanticsForm: React.FC<SemanticsFormProps> = ({
+export const SemanticsForm: FC<SemanticsFormProps> = ({
   fields,
   params,
   parent,
   formClassName,
   onSave,
 }) => {
-  const generatedFormRef = React.useRef<HTMLDivElement>(null);
+  const generatedFormRef = useRef<HTMLDivElement>(null);
   const saveLabel = t('semantics-form_save');
-  const [hasRendered, setHasRendered] = React.useState(false);
+  const [hasRendered, setHasRendered] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setHasRendered(true);
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!generatedFormRef.current || hasRendered) {
       return;
     }

--- a/src/components/ThemePicker/ThemePicker.stories.tsx
+++ b/src/components/ThemePicker/ThemePicker.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { ThemePicker } from './ThemePicker';

--- a/src/components/ThemePicker/ThemePicker.tsx
+++ b/src/components/ThemePicker/ThemePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { ColorTheme } from '../../types/ColorTheme';
 import { themes } from '../../utils/theme.utils';
@@ -9,11 +9,11 @@ export type ThemePickerProps = {
   setTheme: (theme: ColorTheme) => void;
 };
 
-export const ThemePicker: React.FC<ThemePickerProps> = ({
+export const ThemePicker: FC<ThemePickerProps> = ({
   setTheme,
   activeTheme,
 }) => {
-  const renderColorCircles = React.useCallback(
+  const renderColorCircles = useCallback(
     () =>
       Array.from({ length: 4 }).map((_, index) => (
         <span
@@ -25,7 +25,7 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({
     [],
   );
 
-  const colorThemes = React.useMemo(
+  const colorThemes = useMemo(
     () =>
       themes.map(({ labelKey, value }) => (
         <button

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Toolbar } from './Toolbar';

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,5 +1,5 @@
 import type { H5PFieldImage, H5PForm } from 'h5p-types';
-import * as React from 'react';
+import { FC, useCallback, useState } from 'react';
 import { t } from '../../H5P/H5P.util';
 import { Params } from '../../types/Params';
 import { TranslationKey } from '../../types/TranslationKey';
@@ -34,7 +34,7 @@ export type ToolBarProps = {
   parent: H5PForm;
 };
 
-export const Toolbar: React.FC<ToolBarProps> = ({
+export const Toolbar: FC<ToolBarProps> = ({
   setActiveTool,
   activeTool,
   isArrowButtonDisabled,
@@ -43,15 +43,15 @@ export const Toolbar: React.FC<ToolBarProps> = ({
   params,
   parent,
 }) => {
-  const [activeButton, setActiveButton] = React.useState(activeTool);
-  const [appearanceDialogOpen, setAppearanceDialogOpen] = React.useState(false);
+  const [activeButton, setActiveButton] = useState(activeTool);
+  const [appearanceDialogOpen, setAppearanceDialogOpen] = useState(false);
 
   const setActive = (newValue: ToolbarButtonType): void => {
     setActiveButton(activeButton !== newValue ? newValue : null);
     setActiveTool(activeButton !== newValue ? newValue : null);
   };
 
-  const checkIfActive = React.useCallback(
+  const checkIfActive = useCallback(
     (type: ToolbarButtonType) => {
       const activeB = activeButton === type;
       const activeT = activeTool === type;

--- a/src/components/ToolbarButton/ToolbarButton.stories.tsx
+++ b/src/components/ToolbarButton/ToolbarButton.stories.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import * as React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ToolbarButtonType } from '../Toolbar/Toolbar';
 

--- a/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/src/components/ToolbarButton/ToolbarButton.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import styles from './ToolbarButton.module.scss';
+import { FC } from 'react';
 import { Icon } from '../Icons/Icons';
 import { ToolbarButtonType } from '../Toolbar/Toolbar';
+import styles from './ToolbarButton.module.scss';
 
 export type ToolbarButtonProps = {
   icon: ToolbarButtonType;
@@ -12,7 +12,7 @@ export type ToolbarButtonProps = {
   isDisabled: boolean;
 };
 
-export const ToolbarButton: React.FC<ToolbarButtonProps> = ({
+export const ToolbarButton: FC<ToolbarButtonProps> = ({
   icon,
   label,
   onClick,

--- a/src/components/TopicMapItem/TopicMapItem.stories.tsx
+++ b/src/components/TopicMapItem/TopicMapItem.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import { TopicMapItem } from './TopicMapItem';
 
 export default {

--- a/src/components/TopicMapItem/TopicMapItem.tsx
+++ b/src/components/TopicMapItem/TopicMapItem.tsx
@@ -1,5 +1,5 @@
 import { getImageUrl } from 'h5p-utils';
-import * as React from 'react';
+import { FC, useMemo } from 'react';
 import { useAppWidth } from '../../hooks/useAppWidth';
 import { BreakpointSize } from '../../types/BreakpointSize';
 import { TopicMapItemType } from '../../types/TopicMapItemType';
@@ -23,11 +23,11 @@ export type TopicMapItemProps = {
   item: TopicMapItemTypeWithoutPositions;
 };
 
-export const TopicMapItem: React.FC<TopicMapItemProps> = ({ item }) => {
+export const TopicMapItem: FC<TopicMapItemProps> = ({ item }) => {
   const imageUrl = getImageUrl(item.topicImage?.path);
   const AppWidth = useAppWidth();
 
-  const className = React.useMemo(
+  const className = useMemo(
     () => [styles.topicMapItem, sizeClassname[AppWidth]].join(' '),
     [AppWidth],
   );

--- a/src/components/TopicMapItemForm/TopicMapItemForm.stories.tsx
+++ b/src/components/TopicMapItemForm/TopicMapItemForm.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import * as React from 'react';
 import {
   params,
   parent,

--- a/src/components/TopicMapItemForm/TopicMapItemForm.tsx
+++ b/src/components/TopicMapItemForm/TopicMapItemForm.tsx
@@ -1,8 +1,8 @@
 import type { H5PField, H5PFieldGroup, H5PForm } from 'h5p-types';
-import * as React from 'react';
+import {FC, useCallback, useEffect, useState } from 'react';
 import { Params } from '../../types/Params';
-import { getLabel } from '../../utils/arrow.utils';
 import { getTopicMapItemsField } from '../../utils/H5P/form.utils';
+import { getLabel } from '../../utils/arrow.utils';
 import { SemanticsForm } from '../SemanticsForm/SemanticsForm';
 import './TopicMapItemForm.scss';
 
@@ -14,18 +14,17 @@ export type TopicMapItemFormProps = {
   onSave: (params: Params) => void;
 };
 
-export const TopicMapItemForm: React.FC<TopicMapItemFormProps> = ({
+export const TopicMapItemForm: FC<TopicMapItemFormProps> = ({
   semantics,
   params,
   parent,
   itemId,
   onSave,
 }) => {
-  const [topicMapItemsField, setTopicMapItemsField] =
-    React.useState<H5PField | null>();
-  const [formParams, setFormParams] = React.useState<Params>();
+  const [topicMapItemsField, setTopicMapItemsField] = useState<H5PField | null>();
+  const [formParams, setFormParams] = useState<Params>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const field = getTopicMapItemsField(semantics);
     setTopicMapItemsField(field);
 
@@ -39,7 +38,7 @@ export const TopicMapItemForm: React.FC<TopicMapItemFormProps> = ({
     });
   }, [itemId, params, semantics]);
 
-  const onUpdate = React.useCallback(
+  const onUpdate = useCallback(
     (newParams: Params) => {
       if (!newParams.topicMapItems) {
         return;

--- a/src/icons/BiDirectionalArrow.tsx
+++ b/src/icons/BiDirectionalArrow.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type BiDirectionalArrowProps = {
   className: string;
 };
 
-export const BiDirectionalArrow: React.FC<BiDirectionalArrowProps> = ({
+export const BiDirectionalArrow: FC<BiDirectionalArrowProps> = ({
   className,
 }) => {
   return (

--- a/src/icons/CreateArrow.tsx
+++ b/src/icons/CreateArrow.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type CreateArrowProps = {
   className: string;
 };
 
-export const CreateArrow: React.FC<CreateArrowProps> = ({ className }) => {
+export const CreateArrow: FC<CreateArrowProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/icons/CreateBox.tsx
+++ b/src/icons/CreateBox.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type CreateBoxProps = {
   className: string;
 };
 
-export const CreateBox: React.FC<CreateBoxProps> = ({ className }) => {
+export const CreateBox: FC<CreateBoxProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/icons/Delete.tsx
+++ b/src/icons/Delete.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type DeleteProps = {
   className: string;
 };
 
-export const Delete: React.FC<DeleteProps> = ({ className }) => {
+export const Delete: FC<DeleteProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/icons/Edit.tsx
+++ b/src/icons/Edit.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type EditProps = {
   className: string;
 };
 
-export const Edit: React.FC<EditProps> = ({ className }) => {
+export const Edit: FC<EditProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/icons/MapAppearance.tsx
+++ b/src/icons/MapAppearance.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type MapAppearanceProps = {
   className: string;
 };
 
-export const MapAppearance: React.FC<MapAppearanceProps> = ({ className }) => {
+export const MapAppearance: FC<MapAppearanceProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/icons/SingleLine.tsx
+++ b/src/icons/SingleLine.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 export type SingleLineProps = {
   className: string;
 };
 
-export const SingleLine: React.FC<SingleLineProps> = ({ className }) => {
+export const SingleLine: FC<SingleLineProps> = ({ className }) => {
   return (
     <svg
       className={className}

--- a/src/types/ContextMenuAction.tsx
+++ b/src/types/ContextMenuAction.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ContextMenuButtonType } from '../components/ContextMenu/ContextMenu';
 
 export type ContextMenuAction = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "target": "ES2020",
     "allowJs": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "downlevelIteration": true,
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This lets us remove all React imports thatare used just to allow JSX in a file.