### PR TITLE
chore: update h5p-types to v5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint": "^8.57.0",
         "eslint-config-ndla-h5p": "github:ndlano/eslint-config-ndla-h5p",
         "fast-check": "^3.21.0",
-        "h5p-types": "^5.4.0",
+        "h5p-types": "^5.5.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -7095,9 +7095,9 @@
       "license": "MIT"
     },
     "node_modules/h5p-types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-5.4.0.tgz",
-      "integrity": "sha512-txwWsi5XeP+u8Wc4uODEE5pq21MqmvUlIRxMn1t93p9qOsyfokpglgZqdRqbYBqjuN+pSVImD3zFbV8oDAF7aQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-5.5.0.tgz",
+      "integrity": "sha512-nLa096mEzPlJ8LxDxD9vonc6BLmX2L2SBIYzpl3XAVV8aVItWy0WubexkJVjnhxr+NDYxfRCwpjTOG57cuakWQ==",
       "dev": true,
       "dependencies": {
         "@types/jquery": "^3.5.30",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^8.57.0",
     "eslint-config-ndla-h5p": "github:ndlano/eslint-config-ndla-h5p",
     "fast-check": "^3.21.0",
-    "h5p-types": "^5.4.0",
+    "h5p-types": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
`h5p-types` v5.5.0 now allows `list` fields to have `widget` property. We can now keep using `widget: none` for some `list` fields in semantics.json